### PR TITLE
react and superagent moved from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "url": "https://github.com/Granze/react-starterify/issues"
   },
   "homepage": "https://github.com/Granze/react-starterify",
-  "dependencies": {},
+  "dependencies": {
+    "react": "^0.13.0",
+    "superagent": "^1.0.0"
+  },
   "devDependencies": {
     "babelify": "^5.0.4",
     "browser-sync": "^2.2.3",
@@ -38,8 +41,6 @@
     "gulp-sass": "^1.3.3",
     "gulp-sourcemaps": "^1.5.0",
     "gulp-uglify": "^1.1.0",
-    "react": "^0.13.0",
-    "superagent": "^1.0.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^2.4.0"


### PR DESCRIPTION
I think `react` and `superagent` should be `dependencies` and not `devDependencies` as they are useful at runtime.