### PR TITLE
Change url for git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An opinionated React JS application skeleton.
 
 __Clone this repository:__
 
-`git clone git@github.com:Granze/react-starterify.git`
+`git clone https://github.com/Granze/react-starterify.git`
 
 __Install the dependencies:__
 


### PR DESCRIPTION
Using the https url will allow people to clone it without getting a permission denied error.