### PR TITLE
fix autoprefixer now using postcss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var gulp = require('gulp'),
     changed = require('gulp-changed'),
     sass = require('gulp-sass'),
     csso = require('gulp-csso'),
-    autoprefixer = require('gulp-autoprefixer'),
+    autoprefixer = require('autoprefixer-core'),
     browserify = require('browserify'),
     watchify = require('watchify'),
     source = require('vinyl-source-stream'),
@@ -16,6 +16,7 @@ var gulp = require('gulp'),
     notify = require('gulp-notify'),
     browserSync = require('browser-sync'),
     sourcemaps = require('gulp-sourcemaps'),
+    postcss = require('gulp-postcss'),
     reload = browserSync.reload,
     p = {
       jsx: './scripts/app.jsx',
@@ -71,7 +72,7 @@ gulp.task('styles', function() {
     .pipe(changed(p.distCss))
     .pipe(sass({errLogToConsole: true}))
     .on('error', notify.onError())
-    .pipe(autoprefixer('last 1 version'))
+    .pipe(postcss([autoprefixer('last 1 version')]))
     .pipe(csso())
     .pipe(gulp.dest(p.distCss))
     .pipe(reload({stream: true}));

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "superagent": "^1.2.0"
   },
   "devDependencies": {
+    "autoprefixer-core": "^5.2.1",
     "babel": "^5.5.8",
     "babel-eslint": "^3.1.15",
     "babelify": "^6.1.2",
@@ -44,11 +45,11 @@
     "eslint": "^0.23.0",
     "eslint-plugin-react": "^2.5.2",
     "gulp": "^3.9.0",
-    "gulp-autoprefixer": "2.3.1",
     "gulp-changed": "^1.2.1",
     "gulp-csso": "^1.0.0",
     "gulp-eslint": "^0.14.0",
     "gulp-notify": "^2.2.0",
+    "gulp-postcss": "^5.1.9",
     "gulp-sass": "^2.0.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",


### PR DESCRIPTION
This is fixing the warning `Autoprefixer's process() method is deprecated and will removed in next major release.`

I've dropped `gulp-autoprefixer` and introduced [gulp-postcss](https://github.com/postcss/gulp-postcss).