### PR TITLE
Removing named variable to decouple the way components are being designed

### DIFF
--- a/scripts/components/mycomponent.jsx
+++ b/scripts/components/mycomponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import packageJSON from '../../package.json';
 
-let Mycomponent = React.createClass({
+export default React.createClass({
   returnSomething(something) {
     return something;
   },
@@ -24,5 +24,3 @@ let Mycomponent = React.createClass({
     );
   }
 });
-
-export default Mycomponent;


### PR DESCRIPTION
The purpose of this change is removing the dependency on changing the name of a variable within a component's file.

When starting a project using this skeleton, people are used to create components based on the bootstrap and following its conventions, practice that I think isn't healthy since when changing a component's name, it is also the need of changing a variable name.

I know the initial purpose of naming the component within the file is for intuitiveness, but isn't that necessary—the programmer usually doesn't care that much for a variable which is called just once within itself.

Also, this isn't a major thing. Initially retro-compatible, so it's painless to get the project itself updated, guaranteeing developer's comfort.