### PR TITLE
Adding HTML-Replace functionality

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var gulp = require('gulp'),
     sourcemaps = require('gulp-sourcemaps'),
     postcss = require('gulp-postcss'),
     htmlReplace = require('gulp-html-replace'),
+    image = require('gulp-image'),
     reload = browserSync.reload,
     p = {
       jsx: './scripts/app.jsx',
@@ -25,7 +26,8 @@ var gulp = require('gulp'),
       bundle: 'app.js',
       distJs: 'dist/js',
       distCss: 'dist/css',
-      distHtml: 'dist'
+      distHtml: 'dist',
+      distImg: 'dist/img'
     };
 
 gulp.task('clean', function(cb) {
@@ -91,6 +93,12 @@ gulp.task('html-replace', function () {
     .pipe(gulp.dest(p.distHtml));
 });
 
+gulp.task('image', function () {
+  return gulp.src('img/**')
+    .pipe(image())
+    .pipe(gulp.dest(p.distImg));
+});
+
 gulp.task('lint', function() {
   return gulp.src('scripts/**/*.jsx')
     .pipe(eslint())
@@ -103,12 +111,12 @@ gulp.task('watchTask', function() {
 });
 
 gulp.task('watch', ['clean'], function() {
-  gulp.start(['browserSync', 'watchTask', 'watchify', 'styles', 'lint']);
+  gulp.start(['browserSync', 'watchTask', 'watchify', 'styles', 'lint', 'image']);
 });
 
 gulp.task('build', ['clean'], function() {
   process.env.NODE_ENV = 'production';
-  gulp.start(['browserify', 'styles', 'html-replace']);
+  gulp.start(['browserify', 'styles', 'html-replace', 'image']);
 });
 
 gulp.task('default', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,13 +17,15 @@ var gulp = require('gulp'),
     browserSync = require('browser-sync'),
     sourcemaps = require('gulp-sourcemaps'),
     postcss = require('gulp-postcss'),
+    htmlReplace = require('gulp-html-replace'),
     reload = browserSync.reload,
     p = {
       jsx: './scripts/app.jsx',
       scss: 'styles/main.scss',
       bundle: 'app.js',
       distJs: 'dist/js',
-      distCss: 'dist/css'
+      distCss: 'dist/css',
+      distHtml: 'dist'
     };
 
 gulp.task('clean', function(cb) {
@@ -78,6 +80,17 @@ gulp.task('styles', function() {
     .pipe(reload({stream: true}));
 });
 
+gulp.task('html-replace', function () {
+  var replacements = {
+    css: 'css/main.css',
+    js: 'js/app.js'
+  };
+
+  return gulp.src('index.html')
+    .pipe(htmlReplace(replacements))
+    .pipe(gulp.dest(p.distHtml));
+});
+
 gulp.task('lint', function() {
   return gulp.src('scripts/**/*.jsx')
     .pipe(eslint())
@@ -95,7 +108,7 @@ gulp.task('watch', ['clean'], function() {
 
 gulp.task('build', ['clean'], function() {
   process.env.NODE_ENV = 'production';
-  gulp.start(['browserify', 'styles']);
+  gulp.start(['browserify', 'styles', 'html-replace']);
 });
 
 gulp.task('default', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ var gulp = require('gulp'),
     reload = browserSync.reload,
     p = {
       jsx: './scripts/app.jsx',
-      scss: 'styles/main.scss',
+      scss: 'styles/**/*.scss',
       bundle: 'app.js',
       distJs: 'dist/js',
       distCss: 'dist/css',

--- a/index.html
+++ b/index.html
@@ -3,10 +3,16 @@
   <head>
     <meta charset="utf-8">
     <title>React Starterify</title>
+
+    <!-- build:css -->
     <link rel="stylesheet" href="dist/css/main.css">
+    <!-- endbuild -->
   </head>
   <body>
     <div id="content"></div>
+
+    <!-- build:js -->
     <script src="dist/js/app.js"></script>
+    <!-- endbuild -->
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-changed": "^1.2.1",
     "gulp-csso": "^1.0.0",
     "gulp-eslint": "^0.14.0",
+    "gulp-html-replace": "^1.5.1",
     "gulp-notify": "^2.2.0",
     "gulp-postcss": "^5.1.9",
     "gulp-sass": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-csso": "^1.0.0",
     "gulp-eslint": "^0.14.0",
     "gulp-html-replace": "^1.5.1",
+    "gulp-image": "^1.0.1",
     "gulp-notify": "^2.2.0",
     "gulp-postcss": "^5.1.9",
     "gulp-sass": "^2.0.1",


### PR DESCRIPTION
When deploying an application based on **react-starterify**, I got stuck because the `index.html` file is in a different path from the distribution files. A straight forward example is when using a noBackend solution such as [Stamplay](http://stamplay.com).

This need moved me to build this simple solution which transpile the `index.html` file into the `dist/` folder, mapping accordingly the dependencies path automatically, and this only occurs when `gulp build`—it doesn't affect the development environment, live reload or anything else.

Last but not least, through https://github.com/chiefGui/react-starterify/commit/735e0b6b43f1fcc1d3a9d6749d454709cd147d40 I removed the hard watching from `main.scss` for any `.scss` file in the `styles` folder. I did this because I want to watch for the changes in any `.scss` file, being not restricted to `main.scss`. This is good when you use lots of files to style your webapp, like separating them into different folders and hipster structures, using and abusing of the `@import` statement.