### PR TITLE
Add history(explicit requirement for react-router) to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/Granze/react-starterify",
   "dependencies": {
+    "history": "^1.13.1",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-router": "^1.0.0"

--- a/test/components/Powered-by-test.js
+++ b/test/components/Powered-by-test.js
@@ -15,7 +15,7 @@ describe('Powered by', () => {
 
   it('should render the deps list and "react" should be present', () => {
     let ul = poweredBy.props.children.filter(c => c.type === 'ul');
-    let li = ul[0].props.children[0].props.children;
+    let li = ul[0].props.children[1].props.children;
 
     expect(li).to.equal('react');
   });


### PR DESCRIPTION
This is an outstanding [issue](https://github.com/rackt/react-router/issues/2211) with `react-router` that `history` has to be declared as a top-level dependency

Without the dependency, `gulp watch` fails complaining it can't find files associated with `history`