### PR TITLE
Use npm-scripts instead of gulp which is installed globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ __Test:__
 
 __Development mode with livereload:__
 
-`gulp watch`
+`npm run watch`
 
 __When you are done, create a production ready version of the JS bundle:__
 
-`gulp build`
+`npm run build`
 
 ## What's new in v2.0:
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "chai"
   ],
   "scripts": {
-    "test": "mocha --reporter nyan --compilers js:babel/register --recursive"
+    "test": "mocha --reporter nyan --compilers js:babel/register --recursive",
+    "watch": "gulp watch",
+    "build": "gulp build"
   },
   "author": "Maurizio Mangione",
   "license": "MIT",


### PR DESCRIPTION
This pull request enabled users not to install gulp globally before trying to use react-starterify.

It is more minimalistic that all users have to do before trying to use react-starterify is do `npm install`.