### PR TITLE
history fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/Granze/react-starterify",
   "dependencies": {
-    "history": "^1.13.1",
+    "history": "1.13.x",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
-    "react-router": "^1.0.0"
+    "react-router": "^1.0.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/Granze/react-starterify",
   "dependencies": {
-    "history": "1.13.x",
+    "history": "~1.13.x",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-router": "^1.0.2"


### PR DESCRIPTION
npm install does not work
react-router 1.0.2 depends on history@1.13.x, but newer version is downloaded (1.16.0)

fix:
https://github.com/rackt/react-router/issues/2682
http://stackoverflow.com/questions/22343224/difference-between-tilde-and-caret-in-package-json

i am using: node v4.2.3, npm 2.14.7
don't know if it works with npm 3.x