### PR TITLE
fix deprecated dependency from react-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "postcss-nested": "^1.0.0",
     "postcss-simple-extend": "^1.0.0",
     "postcss-simple-vars": "^1.0.0",
-    "react-tools": "^0.13.3",
+    "react-addons-test-utils": "^0.14.3",
     "rimraf": "^2.4.3",
     "run-sequence": "^1.1.2",
     "vinyl-buffer": "^1.0.0",

--- a/test/components/About-test.js
+++ b/test/components/About-test.js
@@ -1,9 +1,9 @@
-import React from 'react/addons';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';
 import About from '../../src/components/About';
 
 describe('About', () => {
-  const {TestUtils} = React.addons;
   const shallowRenderer = TestUtils.createRenderer();
   shallowRenderer.render(<About />);
   const about = shallowRenderer.getRenderOutput();

--- a/test/components/App-test.js
+++ b/test/components/App-test.js
@@ -1,10 +1,10 @@
-import React from 'react/addons';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';
 import App from '../../src/components/App';
 import * as packageJSON from '../../package.json';
 
 describe('App', () => {
-  const {TestUtils} = React.addons;
   const shallowRenderer = TestUtils.createRenderer();
   shallowRenderer.render(<App />);
   const app = shallowRenderer.getRenderOutput();

--- a/test/components/Powered-by-test.js
+++ b/test/components/Powered-by-test.js
@@ -1,10 +1,10 @@
-import React from 'react/addons';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';
 import Poweredby from '../../src/components/Powered-by';
 import * as packageJSON from '../../package.json';
 
 describe('Powered by', () => {
-  const {TestUtils} = React.addons;
   const shallowRenderer = TestUtils.createRenderer();
   shallowRenderer.render(<Poweredby />);
   const poweredBy = shallowRenderer.getRenderOutput();


### PR DESCRIPTION
I removed dependency from `react-tools` (which is deprecated) and added `react-addons-test-utils`.