### PR TITLE
Updates AVA to v0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
     "babel",
     "ava"
   ],
+  "ava": {
+    "require": [
+      "babel-register"
+    ],
+    "babel": "inherit"
+  },
   "scripts": {
     "watch": "gulp watch",
     "build": "gulp build",
@@ -39,12 +45,13 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.0.0",
-    "ava": "^0.9.1",
+    "ava": "^0.13.0",
     "babel": "^6.3.13",
     "babel-core": "^6.3.17",
     "babel-eslint": "^5.0.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
+    "babel-register": "^6.6.5",
     "babelify": "^7.2.0",
     "browser-sync": "^2.9.1",
     "browserify": "^13.0.0",

--- a/test/components/About-test.js
+++ b/test/components/About-test.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import 'babel-core/register';
 import { find } from 'lodash';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';

--- a/test/components/App-test.js
+++ b/test/components/App-test.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import 'babel-core/register';
 import { find } from 'lodash';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';

--- a/test/components/Powered-by-test.js
+++ b/test/components/Powered-by-test.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import 'babel-core/register';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import Poweredby from '../../src/components/Powered-by';


### PR DESCRIPTION
This PR updates AVA to the latest [version](https://github.com/sindresorhus/ava/releases/tag/v0.13.0), released just today, that brings some improvements, most notably the possibility to read you own Babel configuration (through `.babelrc` or `"babel"` key in `package.json`), which was temporarily removed from v0.10.

From v0.10 is also possible to specify AVA configuration in `package.json` under the key `"ava"`, so I've configured it to `"inherit"`( ) the Babel configuration, so it will share the same setting when used by Browserify. 

AVA will also load `'babel-register'` before every file, so importing `'babel-core/register'` is no longer necessary and the package will maybe be deprecated (https://github.com/sindresorhus/ava/issues/561)

PS: I you're experiencing slow execution time, please be sure to be on `npm@3` and reinstall all node packages (https://github.com/sindresorhus/ava/issues/616#issuecomment-194090886)

Thanks!